### PR TITLE
version 2.2.0

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 2.1.0
+current_version = 2.2.0
 commit = True
 tag = True
 tag_name = {new_version}

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 PIPENV_RUN = pipenv run
 
-VERSION := 2.1.0
+VERSION := 2.2.0
 
 help: ## Show this help.
 	@awk 'BEGIN {FS = ":.*?## "} /^[a-zA-Z_-]+:.*?## / {printf "\033[36m%-20s\033[0m %s\n", $$1, $$2}' $(MAKEFILE_LIST) | sort

--- a/bolsa/backend.py
+++ b/bolsa/backend.py
@@ -1,113 +1,93 @@
-import asyncio
 import logging
+from datetime import date
 from functools import cached_property
-
-import aiohttp
+from typing import Any, Dict, List, Union
 
 from bolsa.connector import B3HttpClientConnector
-from bolsa.http_client import B3HttpClient
-from bolsa.responses import (
-    GetBrokerAccountAssetExtractResponse,
-    GetBrokerAccountResponse,
-    GetBrokersResponse
-)
+from bolsa.crawlers import AssetsCrawler, PassiveIncomesCrawler
+from bolsa.models import Broker, BrokerAccount, BrokerAssetExtract, PassiveIncome
 
 logger = logging.getLogger(__name__)
 
 POOL_CONNECTOR = B3HttpClientConnector()
 
 
-class B3AsyncBackend():
-
-    def __init__(self, username, password, captcha_service):
+class B3AsyncBackend:
+    def __init__(
+        self, username: str, password: str, captcha_service: Union[Any, None] = None
+    ):
         self._connector = POOL_CONNECTOR.get_connector()
         self.username = username
         self.password = password
         self.captcha_service = captcha_service
 
     @cached_property
-    def _session(self):
-        logger.info(f'Creating session for username: {self.username}')
-        return aiohttp.ClientSession(
+    def _assets_crawler(self) -> AssetsCrawler:
+        return AssetsCrawler(
             connector=self._connector,
-            connector_owner=False
+            username=self.username,
+            password=self.password,
+            captcha_service=self.captcha_service,
         )
 
     @cached_property
-    def _http_client(self):
-        return B3HttpClient(
+    def _passive_incomes_crawler(self) -> PassiveIncomesCrawler:
+        return PassiveIncomesCrawler(
+            connector=self._connector,
             username=self.username,
             password=self.password,
-            session=self._session,
-            captcha_service=self.captcha_service
+            captcha_service=self.captcha_service,
         )
 
-    async def session_close(self):
-        await self._session.close()
+    async def session_close(self) -> None:
+        await self._assets_crawler.session_close()
+        await self._passive_incomes_crawler.session_close()
 
-    async def connection_close(self):
+    async def connection_close(self) -> None:
         await self._connector.close()
 
-    async def get_brokers(self):
-        response = await self._http_client.get_brokers()
-        response_class = GetBrokersResponse(response)
+    async def get_brokers(self) -> List[Broker]:
+        return await self._assets_crawler.get_brokers()
 
-        return await response_class.data()
+    async def get_broker_accounts(self, broker: Broker) -> Broker:
+        return await self._assets_crawler.get_broker_accounts(broker=broker)
 
-    async def get_broker_accounts(self, broker):
-        response = await self._http_client.get_broker_accounts(broker)
-        response_class = GetBrokerAccountResponse(
-            response=response,
-            broker=broker
-        )
-
-        return await response_class.data()
-
-    async def get_brokers_with_accounts(self):
-        brokers = await self.get_brokers()
-        brokers_account_routine = [
-            asyncio.create_task(
-                self.get_broker_accounts(broker)
-            )
-            for broker in brokers
-        ]
-
-        return await asyncio.gather(*brokers_account_routine)
+    async def get_brokers_with_accounts(self) -> List[Broker]:
+        return await self._assets_crawler.get_brokers_with_accounts()
 
     async def get_broker_account_portfolio_assets_extract(
         self,
-        account_id,
-        broker_value,
-        broker_parse_extra_data,
-        account_parse_extra_data
-    ):
-        response = await self._http_client.get_broker_account_portfolio_assets_extract(  # NOQA
-            account_id,
-            broker_value,
-            broker_parse_extra_data,
-            account_parse_extra_data
-        )
-        response_class = GetBrokerAccountAssetExtractResponse(
-            response=response,
-            broker_value=broker_value
+        broker: Broker,
+        account: BrokerAccount,
+        start_date: Union[date, None] = None,
+        end_date: Union[date, None] = None,
+        as_dict: bool = False,
+    ) -> Union[List[BrokerAssetExtract], List[Dict[str, Any]]]:
+        return await self._assets_crawler.get_broker_account_portfolio_assets_extract(
+            broker=broker,
+            account=account,
+            start_date=start_date,
+            end_date=end_date,
+            as_dict=as_dict,
         )
 
-        return await response_class.data()
+    async def get_brokers_account_portfolio_assets_extract(
+        self,
+        brokers: List[Broker],
+        start_date: Union[date, None] = None,
+        end_date: Union[date, None] = None,
+        as_dict: bool = False,
+    ) -> Union[List[BrokerAssetExtract], List[Dict[str, Any]]]:
+        return await self._assets_crawler.get_brokers_account_portfolio_assets_extract(
+            brokers=brokers,
+            start_date=start_date,
+            end_date=end_date,
+            as_dict=as_dict,
+        )
 
-    async def get_brokers_account_portfolio_assets_extract(self, brokers):
-        brokers_account_assets_extract_routine = [
-            asyncio.create_task(
-                self.get_broker_account_portfolio_assets_extract(
-                    account_id=broker.accounts[0].id,
-                    broker_value=broker.value,
-                    broker_parse_extra_data=broker.parse_extra_data,
-                    account_parse_extra_data=(
-                        broker.accounts[0].parse_extra_data
-                    )
-                )
-            )
-            for broker in brokers
-            if len(broker.accounts) > 0
-        ]
-
-        return await asyncio.gather(*brokers_account_assets_extract_routine)
+    async def get_passive_incomes_extract(
+        self, date: Union[date, None] = None, as_dict: bool = False
+    ) -> Union[List[PassiveIncome], List[Dict[str, Any]]]:
+        return await self._passive_incomes_crawler.get_passive_incomes_extract(
+            date=date, as_dict=as_dict
+        )

--- a/bolsa/backend.py
+++ b/bolsa/backend.py
@@ -5,7 +5,12 @@ from typing import Any, Dict, List, Union
 
 from bolsa.connector import B3HttpClientConnector
 from bolsa.crawlers import AssetsCrawler, PassiveIncomesCrawler
-from bolsa.models import Broker, BrokerAccount, BrokerAssetExtract, PassiveIncome
+from bolsa.models import (
+    Broker,
+    BrokerAccount,
+    BrokerAssetExtract,
+    PassiveIncome
+)
 
 logger = logging.getLogger(__name__)
 

--- a/bolsa/constants.py
+++ b/bolsa/constants.py
@@ -3,26 +3,52 @@ from enum import Enum, unique
 
 @unique
 class BrokerAssetExtractAction(Enum):
-    BUY = 'buy'
-    SELL = 'sell'
+    BUY = "buy"
+    SELL = "sell"
 
 
 @unique
 class BrokerAssetExtractMarketType(Enum):
-    FRACTIONAL = 'fractional_share'
-    UNIT = 'unit'
-    OPTIONS = 'options'
+    FRACTIONAL = "fractional_share"
+    UNIT = "unit"
+    OPTIONS = "options"
 
 
 ASSET_ACTION_TYPE_MAPPER = {
-    'C': BrokerAssetExtractAction.BUY.value,
-    'V': BrokerAssetExtractAction.SELL.value,
+    "C": BrokerAssetExtractAction.BUY.value,
+    "V": BrokerAssetExtractAction.SELL.value,
 }
 
 ASSET_MARKET_TYPE_MAPPER = {
-    'Merc. Fracionário': BrokerAssetExtractMarketType.FRACTIONAL.value,
-    'Mercado a Vista': BrokerAssetExtractMarketType.UNIT.value,
-    'Opção de Compra': BrokerAssetExtractMarketType.OPTIONS.value,
-    'Opção de Venda': BrokerAssetExtractMarketType.OPTIONS.value,
-    'Exercicio de Opções': BrokerAssetExtractMarketType.OPTIONS.value
+    "Merc. Fracionário": BrokerAssetExtractMarketType.FRACTIONAL.value,
+    "Mercado a Vista": BrokerAssetExtractMarketType.UNIT.value,
+    "Opção de Compra": BrokerAssetExtractMarketType.OPTIONS.value,
+    "Opção de Venda": BrokerAssetExtractMarketType.OPTIONS.value,
+    "Exercicio de Opções": BrokerAssetExtractMarketType.OPTIONS.value,
+}
+
+
+@unique
+class PassiveIncomeType(Enum):
+    FUTURE = "provisioned"
+    PAST = "credited"
+
+
+PASSIVE_INCOME_TYPE_MAPPER = {
+    "Provisionado": PassiveIncomeType.FUTURE.value,
+    "Creditado": PassiveIncomeType.PAST.value,
+}
+
+
+@unique
+class PassiveIncomeEventType(Enum):
+    DIVIDEND = "dividend"
+    JCP = "jcp"
+    YIELD = "FII yield"
+
+
+PASSIVE_INCOME_EVENT_TYPE_MAPPER = {
+    "DIVIDENDO": PassiveIncomeEventType.DIVIDEND.value,
+    "JUROS SOBRE CAPITAL PRÓPRIO": PassiveIncomeEventType.JCP.value,
+    "RENDIMENTO": PassiveIncomeEventType.YIELD.value,
 }

--- a/bolsa/crawlers.py
+++ b/bolsa/crawlers.py
@@ -1,0 +1,288 @@
+import asyncio
+import logging
+from datetime import date
+from functools import cached_property
+from typing import Any, Dict, List, Type, Union
+
+from aiohttp import ClientSession
+from aiohttp.connector import TCPConnector
+
+from bolsa.http_client import B3HttpClient
+from bolsa.models import Broker, BrokerAccount, BrokerAssetExtract, PassiveIncome
+from bolsa.responses import (
+    BrokerAccountAssetExtractResponse,
+    BrokerAccountResponse,
+    BrokerAssetsResponse,
+    BrokerPassiveIncomesResponse,
+    PassiveIncomesResponse,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class BaseCrawler:
+    def __init__(
+        self,
+        connector: TCPConnector,
+        username: str,
+        password: str,
+        captcha_service: Any,
+    ) -> None:
+        self.connector = connector
+        self.username = username
+        self.password = password
+        self.captcha_service = captcha_service
+
+    @cached_property
+    def _session(self) -> ClientSession:
+        logger.info(f"Creating session for username: {self.username}")
+        return ClientSession(connector=self.connector, connector_owner=False)
+
+    @cached_property
+    def _http_client(self) -> B3HttpClient:
+        return B3HttpClient(
+            username=self.username,
+            password=self.password,
+            session=self._session,
+            captcha_service=self.captcha_service,
+            base_url=self.get_base_url(),
+        )
+
+    def get_base_url(self) -> str:
+        raise NotImplementedError()
+
+    def get_brokers_response_class(self) -> Any:
+        raise NotImplementedError()
+
+    def _get_broker_accounts_payload(
+        self, broker: Broker
+    ) -> Dict[str, Union[str, bool]]:
+        raise NotImplementedError()
+
+    async def session_close(self) -> None:
+        await self._session.close()
+
+    async def connection_close(self) -> None:
+        await self.connector.close()
+
+    async def get_brokers(self) -> List[Broker]:
+        response = await self._http_client.get_brokers()
+        ResponseClass = self.get_brokers_response_class()
+
+        return await ResponseClass(response).data()
+
+    async def get_broker_accounts(self, broker: Broker) -> Broker:
+        logger.info(
+            f"B3HttpClient getting brokers account - username: {self.username}"
+            f" broker_value: {broker.value}"
+        )
+
+        response = await self._http_client.get_broker_accounts(
+            self._get_broker_accounts_payload(broker=broker)
+        )
+
+        logger.info(
+            f"B3HttpClient end getting brokers account - "
+            f"username: {self.username} broker_value: {broker.value}"
+        )
+
+        return await BrokerAccountResponse(response=response, broker=broker).data()
+
+    async def get_brokers_with_accounts(self) -> List[Broker]:
+        brokers = await self.get_brokers()
+        tasks = [
+            asyncio.create_task(self.get_broker_accounts(broker)) for broker in brokers
+        ]
+
+        return await asyncio.gather(*tasks)
+
+
+class AssetsCrawler(BaseCrawler):
+    def get_base_url(self) -> str:
+        return "https://ceiapp.b3.com.br/CEI_Responsivo/negociacao-de-ativos.aspx"
+
+    def get_brokers_response_class(self) -> Type[BrokerAssetsResponse]:
+        return BrokerAssetsResponse
+
+    def _get_broker_accounts_payload(
+        self, broker: Broker
+    ) -> Dict[str, Union[str, bool]]:
+        default_account = "0"
+
+        return {
+            "ctl00$ContentPlaceHolder1$ToolkitScriptManager1": (
+                "ctl00$ContentPlaceHolder1$updFiltro|ctl00$ContentPlaceHolder1"
+                "$ddlAgentes"
+            ),
+            "__EVENTTARGET": "ctl00$ContentPlaceHolder1$ddlAgentes",
+            "__VIEWSTATE": (
+                "/wEPDwUKLTI2MTA0ODczNg9kFgJmD2QWAgIDD2QWCAIBDw8WAh4EVGV4dAUcR"
+                "0lPVkFOTkkgQ09STkFDSElOSSBEQSBTSUxWQWRkAgMPZBYCAgEPFgIeB1Zpc2"
+                "libGVoZAIFD2QWBAIBDw8WAh8ABRZOZWdvY2lhw6fDo28gZGUgYXRpdm9zZGQ"
+                "CAw9kFgICAw8PFgIfAAUzIC8gRXh0cmF0b3MgZSBJbmZvcm1hdGl2b3MgLyBO"
+                "ZWdvY2lhw6fDo28gZGUgYXRpdm9zZGQCBw9kFgICBQ9kFgJmD2QWCAIDDxBkE"
+                "BUFCVNlbGVjaW9uZR85MCAtIEVBU1lOVkVTVCAtIFRJVFVMTyBDViBTLkEuHj"
+                "MgLSBYUCBJTlZFU1RJTUVOVE9TIENDVFZNIFMvQSMzODYgLSBSSUNPIElOVkV"
+                "TVElNRU5UT1MgLSBHUlVQTyBYUCAzMDggLSBDTEVBUiBDT1JSRVRPUkEgLSBH"
+                "UlVQTyBYUBUFAi0xAjkwATMDMzg2AzMwOBQrAwVnZ2dnZxYBZmQCBQ8QDxYCH"
+                "gdFbmFibGVkaGQQFQEMU2VsZWNpb25lLi4uFQEBMBQrAwFnFgFmZAIHDw8WAh"
+                "8BZ2QWBAIFDw8WAh8ABQoxNS8wMy8yMDE5ZGQCBw8PFgIfAAUKMDQvMDkvMjA"
+                "yMGRkAgkPZBYIAgEPDxYCHwAFCjE1LzAzLzIwMTlkZAIDDw8WAh8ABQowNC8"
+                "wOS8yMDIwZGQCBQ8PFgIfAAUKMTUvMDMvMjAxOWRkAgcPDxYCHwAFCjA0LzA5"
+                "LzIwMjBkZGRxwKn9JGbY4ybO1hczEjDtoMNWHA=="
+            ),
+            "__VIEWSTATEGENERATOR": "B345DEBA",
+            "__EVENTVALIDATION": (
+                "/wEdAA1HJ2+J0WZq5G92xJM7n1xbkdMq+p9EbLSDyFDpFsJg30jWLhbIoNprA"
+                "gvONYSktR9kUdPnKtUYGLSZMc/L6M60Vx7WZDZAC7VL6Ff5PQQ8Ml0aq/zmKf"
+                "YeYoLRE68kUnN+T4cvEJcdEKVEObT+JUFSdPwdZycbAgmz2rhziqC/I4jipT0"
+                "jOBb54glnPZxI9VIJZJh1VhVVa0UQ15FhckhgajRdmhEnQj18gON7y5L4CwGM"
+                "p96e++H/oSCxgpNo73nsffQOO+5kepETTltW2pZIXYv2PXYLNUXZnEOvnHkp6"
+                "xZ0N94="
+            ),
+            "ctl00$ContentPlaceHolder1$ddlAgentes": broker.value,
+            "ctl00$ContentPlaceHolder1$ddlContas": default_account,
+            "ctl00$ContentPlaceHolder1$txtDataDeBolsa": broker.parse_extra_data.start_date,
+            "ctl00$ContentPlaceHolder1$txtDataAteBolsa": broker.parse_extra_data.end_date,
+            "__ASYNCPOST": True,
+        }
+
+    async def get_broker_account_portfolio_assets_extract(
+        self,
+        broker: Broker,
+        account: BrokerAccount,
+        start_date: Union[date, None] = None,
+        end_date: Union[date, None] = None,
+        as_dict: bool = False,
+    ) -> Union[List[BrokerAssetExtract], List[Dict[str, Any]]]:
+        response = await self._http_client.get_broker_account_portfolio_assets_extract(
+            broker=broker,
+            account=account,
+            start_date=start_date,
+            end_date=end_date,
+        )
+        return await BrokerAccountAssetExtractResponse(
+            response=response, broker_value=broker.value
+        ).data(as_dict=as_dict)
+
+    async def get_brokers_account_portfolio_assets_extract(
+        self,
+        brokers: List[Broker],
+        start_date: Union[date, None] = None,
+        end_date: Union[date, None] = None,
+        as_dict: bool = False,
+    ) -> Union[List[BrokerAssetExtract], List[Dict[str, Any]]]:
+        tasks = [
+            asyncio.create_task(
+                self.get_broker_account_portfolio_assets_extract(
+                    broker=broker,
+                    account=broker.accounts[0],
+                    start_date=start_date,
+                    end_date=end_date,
+                    as_dict=as_dict,
+                )
+            )
+            for broker in brokers
+            if broker.accounts
+        ]
+
+        results = await asyncio.gather(*tasks)
+        return [result for subresult in results for result in subresult]
+
+
+class PassiveIncomesCrawler(BaseCrawler):
+    def get_base_url(self) -> str:
+        return "https://ceiapp.b3.com.br/CEI_Responsivo/ConsultarProventos.aspx"
+
+    def get_brokers_response_class(self) -> Type[BrokerPassiveIncomesResponse]:
+        return BrokerPassiveIncomesResponse
+
+    def _get_broker_accounts_payload(
+        self, broker: Broker
+    ) -> Dict[str, Union[str, bool]]:
+        default_account = "0"
+
+        return {
+            "ctl00$ContentPlaceHolder1$ToolkitScriptManager1": (
+                "ctl00$ContentPlaceHolder1$updFiltro|ctl00$ContentPlaceHolder1"
+                "$ddlAgentes"
+            ),
+            "__EVENTTARGET": "ctl00$ContentPlaceHolder1$ddlAgentes",
+            "__VIEWSTATE": (
+                "/wEPDwULLTEwMDg3NTU3MTAPZBYCZg9kFgICAw9kFggCAQ8PFgIeBFRleHQFF1dBR05"
+                "FUiBWSUVMTU8gREUgQ0FNUE9TZGQCAw9kFgICAQ8WAh4HVmlzaWJsZWhkAgUPZBYEAgE"
+                "PDxYCHwAFCVByb3ZlbnRvc2RkAgMPZBYCAgMPDxYCHwAFHCAvIEludmVzdGltZW50b3M"
+                "gLyBQcm92ZW50b3NkZAIHD2QWAgIFD2QWAmYPZBYMAgEPZBYCAgEPEGQQFQMFVG9kb3M"
+                "WMTk4MiAtIE1PREFMIERUVk0gTFREQSMzODYgLSBSSUNPIElOVkVTVElNRU5UT1MgLSB"
+                "HUlVQTyBYUBUDATAEMTk4MgMzODYUKwMDZ2dnFgFmZAIDD2QWAgIBDxAPFgIeB0VuYWJ"
+                "sZWRoZBAVAwVUb2RvcwYzNDUwMzAHMTg1OTAzNhUDATAGMzQ1MDMwBzE4NTkwMzYUKwM"
+                "DZ2dnFgFmZAIFDxYCHwFoFgICAQ8QZGQWAGQCBw9kFgYCAQ8PFgQeCENzc0NsYXNzBQp"
+                "kYXRlcGlja2VyHgRfIVNCAgJkZAIDDw8WAh8ABQoxNC8wNi8yMDIxZGQCBQ8PFgIfAAU"
+                "KMTcvMDYvMjAyMWRkAgsPFgIfAWcWAgIBDw8WAh8ABSFBdHVhbGl6YWRvIGVtIDE3LzA"
+                "2LzIwMjEgYXMgMjI6MDlkZAINDxYCHgtfIUl0ZW1Db3VudAIBFgJmD2QWBAIBDw8WAh8"
+                "ABSMzODYgLSBSSUNPIElOVkVTVElNRU5UT1MgLSBHUlVQTyBYUGRkAgMPFgIfBQIBFgJ"
+                "mD2QWCgIBDw8WAh8ABRNDb250YSBuwrogMTg1OTAzNi05ZGQCAw9kFgICAQ8WAh8FAgI"
+                "WBgIBD2QWAmYPFQkMRU5FUkdJQVMgQlIgCk9OICAgICAgTk0MRU5CUjMgICAgICAgCjI"
+                "zLzA2LzIwMjEcSlVST1MgU09CUkUgQ0FQSVRBTCBQUsOTUFJJTwU0LDAwMAExBDEsMDg"
+                "EMCw5MmQCAg9kFgJmDxUJDEZJSSBDQVBJIFNFQwpDSSAgICAgICAgDENQVFMxMSAgICA"
+                "gIAoxOC8wNi8yMDIxClJFTkRJTUVOVE8FMSwwMDABMQQxLDAwBDEsMDBkAgMPZBYEAgE"
+                "PDxYCHwAFBDIsMDhkZAIDDw8WAh8ABQQxLDkyZGQCBQ9kFgICAQ8WAh8FAhEWJAIBD2Q"
+                "WAmYPFQkMRklJIEJDIEZGSUkgCkNJICAgICAgICAMQkNGRjExICAgICAgCjE1LzA2LzIw"
+                "MjEKUkVORElNRU5UTwUzLDAwMAExBDEsNTAEMSw1MGQCAg9kFgJmDxUJDEZJSSBCRUVTI"
+                "ENSSQpDSSAgICAgICAgDEJDUkkxMSAgICAgIAoxNS8wNi8yMDIxClJFTkRJTUVOVE8GMT"
+                "AsMDAwATEFMTUsOTAFMTUsOTBkAgMPZBYCZg8VCQxGSUkgQ1NIRyBMT0cKQ0kgICAgICAg"
+                "IAxIR0xHMTEgICAgICAKMTUvMDYvMjAyMQpSRU5ESU1FTlRPBjExLDAwMAExBTExLDAwBT"
+                "ExLDAwZAIED2QWAmYPFQkMRklJIENTSEcgVVJCCkNJICAgICAgICAMSEdSVTExICAgICAg"
+                "CjE1LzA2LzIwMjEKUkVORElNRU5UTwYxMCwwMDABMQQ3LDAwBDcsMDBkAgUPZBYCZg8VCQ"
+                "xGSUkgREVWQU5UICAKQ0kgICAgICAgIAxERVZBMTEgICAgICAKMTUvMDYvMjAyMQpSRU5E"
+                "SU1FTlRPBjIwLDAwMAExBTIyLDAwBTIyLDAwZAIGD2QWAmYPFQkMRklJIERFVkFOVCAgCl"
+                "JFQyAgICAgICAMREVWQTEzICAgICAgCjE1LzA2LzIwMjEKUkVORElNRU5UTwYxMSwwMDAB"
+                "MQQxLDQzBDEsNDNkAgcPZBYCZg8VCQxGSUkgRkFUT1IgVkUKQ0kgICAgICAgIAxWUlRBMT"
+                "EgICAgICAKMTUvMDYvMjAyMQpSRU5ESU1FTlRPBTEsMDAwATEEMSwwNAQxLDA0ZAIID2QW"
+                "AmYPFQkMRklJIEhHIFJFQUwgCkNJICAgICAgICAMSEdSRTExICAgICAgCjE1LzA2LzIwMj"
+                "EKUkVORElNRU5UTwU2LDAwMAExBDQsMTQENCwxNGQCCQ9kFgJmDxUJDEZJSSBJUklESVVN"
+                "IApDSSAgICAgICAgDElSRE0xMSAgICAgIAoxNy8wNi8yMDIxClJFTkRJTUVOVE8GMjgsMD"
+                "AwATEFMzIsMzAFMzIsMzBkAgoPZBYCZg8VCQxGSUkgS0lORUEgICAKQ0kgICAgICAgIAxL"
+                "TlJJMTEgICAgICAKMTUvMDYvMjAyMQpSRU5ESU1FTlRPBjEwLDAwMAExBDYsOTAENiw5MG"
+                "QCCw9kFgJmDxUJDEZJSSBLSU5FQSBJUApDSSAgICAgICAgDEtOSVAxMSAgICAgIAoxNC8w"
+                "Ni8yMDIxClJFTkRJTUVOVE8FNSwwMDABMQQ1LDY1BDUsNjVkAgwPZBYCZg8VCQxGSUkgTU"
+                "FYSSBSRU4KQ0kgICAgICAgIAxNWFJGMTEgICAgICAKMTUvMDYvMjAyMQpSRU5ESU1FTlRP"
+                "BzE2NSwwMDABMQUxMSw1NQUxMSw1NWQCDQ9kFgJmDxUJDEZJSSBUT1JERSBFSQpDSSAgICA"
+                "gICAgDFRPUkQxMSAgICAgIAoxNS8wNi8yMDIxClJFTkRJTUVOVE8GNDcsMDAwATEEMywyOQ"
+                "QzLDI5ZAIOD2QWAmYPFQkMRklJIFRPUkRFIEVJClJFQyAgICAgICAMVE9SRDEzICAgICAgC"
+                "jE1LzA2LzIwMjEKUkVORElNRU5UTwYxNSwwMDABMQQwLDU1BDAsNTVkAg8PZBYCZg8VCQxG"
+                "SUkgVkVSUyBDUkkKQ0kgICAgICAgIAxWU0xIMTEgICAgICAKMTUvMDYvMjAyMQpSRU5ESU1"
+                "FTlRPBTUsMDAwATEEMCw4NQQwLDg1ZAIQD2QWAmYPFQkMRklJIFZJTkNJTE9HCkNJICAgIC"
+                "AgICAMVklMRzExICAgICAgCjE1LzA2LzIwMjEKUkVORElNRU5UTwU0LDAwMAExBDIsMjgEM"
+                "iwyOGQCEQ9kFgJmDxUJDEZJSSBYUCBMT0cgIApDSSAgICAgICAgDFhQTEcxMSAgICAgIAox"
+                "NS8wNi8yMDIxClJFTkRJTUVOVE8FNiwwMDABMQQzLDY2BDMsNjZkAhIPZBYEAgEPDxYCHwA"
+                "FBjEzMSwwNGRkAgMPDxYCHwAFBjEzMSwwNGRkAgcPFgIfAWgWAgIBDxYCHwUC/////w9kAg"
+                "kPZBYCAgEPFgIfBQIBFgQCAQ9kFgJmDxULDEZJSSBUT1JERSBFSQpSRUMgICAgICAgDFRPU"
+                "kQxMyAgICAgIAtBVFVBTElaQUNBTwoxNy8wNi8yMDIxBjE1LDAwMAExDFRPUkQxMSAgICAg"
+                "IAUxNSwwMAYxMDAsMDAEMCwwMGQCAg9kFgICAQ8PFgIfAAUEMCwwMGRkZNmTebZZFDui/ij"
+                "Eax1lX4ugM/e1"
+            ),
+            "__VIEWSTATEGENERATOR": "60D025E9",
+            "__EVENTVALIDATION": (
+                "/wEdAAz3Yx2ES4cT5dCIgXUVBTgKSNYuFsig2msCC841hKS1H1GNyhN3N1osq"
+                "BqqgaNItpdZDO+9C9gz5Aw/AZYSIzXhfk+HLxCXHRClRDm0/iVBUojipT0jOB"
+                "b54glnPZxI9VIJZJh1VhVVa0UQ15FhckhgY2JNro3bvLeSMJrpn9aSiHkRxwu"
+                "EE8o8LwrE2E6mACtDmhxe4pZ6Ibt8oBWfF3Ts7H30DjvuZHqRE05bVtqWSPOO"
+                "FWTf/Hn+MVE/ujXYFJTWLVokCvgbtFxjrfYgYXuQJX3w9w=="
+            ),
+            "ctl00$ContentPlaceHolder1$ddlAgentes": broker.value,
+            "ctl00$ContentPlaceHolder1$ddlContas": default_account,
+            "ctl00$ContentPlaceHolder1$txtData": broker.parse_extra_data.end_date,
+            "__ASYNCPOST": True,
+        }
+
+    async def get_passive_incomes_extract(
+        self, date: Union[date, None] = None, as_dict: bool = False
+    ) -> Union[List[PassiveIncome], List[Dict[str, Any]]]:
+        brokers = await self.get_brokers_with_accounts()
+        response = await self._http_client.get_passive_incomes_extract(
+            broker=brokers[0],  # brokers[0] is the broker with all accounts
+            date=date,
+        )
+
+        return await PassiveIncomesResponse(response=response).data(as_dict=as_dict)

--- a/bolsa/crawlers.py
+++ b/bolsa/crawlers.py
@@ -8,13 +8,18 @@ from aiohttp import ClientSession
 from aiohttp.connector import TCPConnector
 
 from bolsa.http_client import B3HttpClient
-from bolsa.models import Broker, BrokerAccount, BrokerAssetExtract, PassiveIncome
+from bolsa.models import (
+    Broker,
+    BrokerAccount,
+    BrokerAssetExtract,
+    PassiveIncome
+)
 from bolsa.responses import (
     BrokerAccountAssetExtractResponse,
     BrokerAccountResponse,
     BrokerAssetsResponse,
     BrokerPassiveIncomesResponse,
-    PassiveIncomesResponse,
+    PassiveIncomesResponse
 )
 
 logger = logging.getLogger(__name__)

--- a/bolsa/exceptions.py
+++ b/bolsa/exceptions.py
@@ -1,0 +1,2 @@
+class B3UnableToLoginException(Exception):
+    pass

--- a/bolsa/http_client.py
+++ b/bolsa/http_client.py
@@ -1,98 +1,107 @@
 import logging
+from datetime import date, datetime
+from typing import Union
+from urllib.parse import urljoin, urlparse
 
+from aiohttp.client_reqrep import ClientResponse
 from bs4 import BeautifulSoup
 
 from bolsa.connector import B3HttpClientConnector
+from bolsa.exceptions import B3UnableToLoginException
+from bolsa.models import Broker, BrokerAccount
 
 logger = logging.getLogger(__name__)
 
 POOL_CONNECTOR = B3HttpClientConnector()
 
 
-class B3HttpClient():
+class B3HttpClient:
     IS_LOGGED = False
     SESSION = None
-    LOGIN_URL = 'https://ceiapp.b3.com.br/CEI_Responsivo/login.aspx'
+    LOGIN_URL = "https://ceiapp.b3.com.br/CEI_Responsivo/login.aspx"
+    _HEADERS_ORIGIN_URL = "https://cei.b3.com.br"
 
-    ASSETS_HOME_URL = (
-        'https://ceiapp.b3.com.br/CEI_Responsivo/negociacao-de-ativos.aspx'
-    )
-    BROKERS_ACCOUNT_URL = (
-        'https://ceiapp.b3.com.br/CEI_Responsivo/negociacao-de-ativos.aspx'
-    )
-    ASSETS_URL = (
-        'https://ceiapp.b3.com.br/CEI_Responsivo/negociacao-de-ativos.aspx'
-    )
-
-    def __init__(self, username, password, session, captcha_service):
+    def __init__(self, username, password, session, captcha_service, base_url):
         self.username = username
         self.password = password
         self.session = session
         self.captcha_service = captcha_service
+        self.base_url = base_url
+
+    def _get_referer(self):
+        return urljoin(self._HEADERS_ORIGIN_URL, urlparse(self.base_url).path)
+
+    def _get_headers(self):
+        return {
+            "content-type": "application/x-www-form-urlencoded; charset=UTF-8",
+            "Referer": self._get_referer(),
+            "Origin": self._HEADERS_ORIGIN_URL,
+            "User-Agent": (
+                "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_6) "
+                "AppleWebKit/537.36 (KHTML, like Gecko) Chrome/84.0.4147.135 "
+                "Safari/537.36"
+            ),
+        }
 
     async def login(self):
-        async with self.session.get(
-            self.LOGIN_URL
-        ) as response:
+        async with self.session.get(self.LOGIN_URL) as response:
             loginPageContent = await response.text()
             loginPageParsed = BeautifulSoup(loginPageContent, "html.parser")
-            view_state = loginPageParsed.find(id='__VIEWSTATE')['value']
-            viewstate_generator = loginPageParsed.find(
-                id='__VIEWSTATEGENERATOR'
-            )['value']
-            event_validation = loginPageParsed.find(
-                id='__EVENTVALIDATION'
-            )['value']
+            try:
+                view_state = loginPageParsed.find(id="__VIEWSTATE")["value"]
+                viewstate_generator = loginPageParsed.find(id="__VIEWSTATEGENERATOR")[
+                    "value"
+                ]
+                event_validation = loginPageParsed.find(id="__EVENTVALIDATION")["value"]
+            except TypeError as e:
+                raise B3UnableToLoginException(repr(e))
 
             solvedcaptcha = None
             if self.captcha_service:
                 site_key = loginPageParsed.find(
-                    id='ctl00_ContentPlaceHolder1_dvCaptcha'
-                ).get(
-                    'data-sitekey'
-                )
+                    id="ctl00_ContentPlaceHolder1_dvCaptcha"
+                ).get("data-sitekey")
                 solvedcaptcha = await self.captcha_service.resolve(
-                    site_key,
-                    self.LOGIN_URL
+                    site_key, self.LOGIN_URL
                 )
 
         payload = {
-            'ctl00$ContentPlaceHolder1$smLoad': (
-                'ctl00$ContentPlaceHolder1$UpdatePanel1|ctl00$ContentPlaceHold'
-                'er1$btnLogar'
+            "ctl00$ContentPlaceHolder1$smLoad": (
+                "ctl00$ContentPlaceHolder1$UpdatePanel1|ctl00$ContentPlaceHold"
+                "er1$btnLogar"
             ),
-            '__EVENTTARGET': '',
-            '__EVENTARGUMENT': '',
-            '__VIEWSTATEGENERATOR': viewstate_generator,
-            '__EVENTVALIDATION': event_validation,
-            '__VIEWSTATE': view_state,
-            'ctl00$ContentPlaceHolder1$txtLogin': self.username,
-            'ctl00$ContentPlaceHolder1$txtSenha': self.password,
-            '__ASYNCPOST': True,
-            'g-recaptcha-response': solvedcaptcha,
-            'ctl00$ContentPlaceHolder1$btnLogar': 'Entrar'
+            "__EVENTTARGET": "",
+            "__EVENTARGUMENT": "",
+            "__VIEWSTATEGENERATOR": viewstate_generator,
+            "__EVENTVALIDATION": event_validation,
+            "__VIEWSTATE": view_state,
+            "ctl00$ContentPlaceHolder1$txtLogin": self.username,
+            "ctl00$ContentPlaceHolder1$txtSenha": self.password,
+            "__ASYNCPOST": True,
+            "g-recaptcha-response": solvedcaptcha,
+            "ctl00$ContentPlaceHolder1$btnLogar": "Entrar",
         }
 
         headers = {
-            'content-type': 'application/x-www-form-urlencoded; charset=UTF-8',
-            'Referer': 'https://cei.b3.com.br/CEI_Responsivo/login.aspx',
-            'Origin': 'https://cei.b3.com.br',
-            'Host': 'cei.b3.com.br',
-            'User-Agent': (
-                'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_5) '
-                'AppleWebKit/537.36 (KHTML, like Gecko) Chrome/84.0.4147.135 '
-                'Safari/537.36'
+            "content-type": "application/x-www-form-urlencoded; charset=UTF-8",
+            "Referer": "https://cei.b3.com.br/CEI_Responsivo/login.aspx",
+            "Origin": self._HEADERS_ORIGIN_URL,
+            "Host": "cei.b3.com.br",
+            "User-Agent": (
+                "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_5) "
+                "AppleWebKit/537.36 (KHTML, like Gecko) Chrome/84.0.4147.135 "
+                "Safari/537.36"
             ),
         }
 
-        logger.info(f'B3HttpClient doing login - username: {self.username}')
+        logger.info(f"B3HttpClient doing login - username: {self.username}")
 
         async with self.session.post(
             self.LOGIN_URL,
             data=payload,
             headers=headers,
         ) as response:
-            logger.info(f'B3HttpClient login done - username: {self.username}')
+            logger.info(f"B3HttpClient login done - username: {self.username}")
 
             self.IS_LOGGED = True
 
@@ -102,150 +111,114 @@ class B3HttpClient():
         if not self.IS_LOGGED:
             await self.login()
 
-        logger.info(
-            f'B3HttpClient getting brokers - username: {self.username}'
-        )
+        logger.info(f"B3HttpClient getting brokers - username: {self.username}")
 
-        response = await self.session.get(self.ASSETS_HOME_URL)
-        logger.info(
-            f'B3HttpClient end getting brokers - username: {self.username}'
-        )
+        response = await self.session.get(self.base_url)
+        logger.info(f"B3HttpClient end getting brokers - username: {self.username}")
 
         return response
 
-    async def get_broker_accounts(self, broker):
+    async def get_broker_accounts(self, payload):
         if not self.IS_LOGGED:
             await self.login()
 
-        default_account = '0'
-        start_date = broker.parse_extra_data.start_date
-        end_date = broker.parse_extra_data.end_date
-
-        payload = {
-            'ctl00$ContentPlaceHolder1$ToolkitScriptManager1': (
-                'ctl00$ContentPlaceHolder1$updFiltro|ctl00$ContentPlaceHolder1'
-                '$ddlAgentes'
-            ),
-            '__EVENTTARGET': 'ctl00$ContentPlaceHolder1$ddlAgentes',
-            '__VIEWSTATE': (
-                '/wEPDwUKLTI2MTA0ODczNg9kFgJmD2QWAgIDD2QWCAIBDw8WAh4EVGV4dAUcR'
-                '0lPVkFOTkkgQ09STkFDSElOSSBEQSBTSUxWQWRkAgMPZBYCAgEPFgIeB1Zpc2'
-                'libGVoZAIFD2QWBAIBDw8WAh8ABRZOZWdvY2lhw6fDo28gZGUgYXRpdm9zZGQ'
-                'CAw9kFgICAw8PFgIfAAUzIC8gRXh0cmF0b3MgZSBJbmZvcm1hdGl2b3MgLyBO'
-                'ZWdvY2lhw6fDo28gZGUgYXRpdm9zZGQCBw9kFgICBQ9kFgJmD2QWCAIDDxBkE'
-                'BUFCVNlbGVjaW9uZR85MCAtIEVBU1lOVkVTVCAtIFRJVFVMTyBDViBTLkEuHj'
-                'MgLSBYUCBJTlZFU1RJTUVOVE9TIENDVFZNIFMvQSMzODYgLSBSSUNPIElOVkV'
-                'TVElNRU5UT1MgLSBHUlVQTyBYUCAzMDggLSBDTEVBUiBDT1JSRVRPUkEgLSBH'
-                'UlVQTyBYUBUFAi0xAjkwATMDMzg2AzMwOBQrAwVnZ2dnZxYBZmQCBQ8QDxYCH'
-                'gdFbmFibGVkaGQQFQEMU2VsZWNpb25lLi4uFQEBMBQrAwFnFgFmZAIHDw8WAh'
-                '8BZ2QWBAIFDw8WAh8ABQoxNS8wMy8yMDE5ZGQCBw8PFgIfAAUKMDQvMDkvMjA'
-                'yMGRkAgkPZBYIAgEPDxYCHwAFCjE1LzAzLzIwMTlkZAIDDw8WAh8ABQowNC8'
-                'wOS8yMDIwZGQCBQ8PFgIfAAUKMTUvMDMvMjAxOWRkAgcPDxYCHwAFCjA0LzA5'
-                'LzIwMjBkZGRxwKn9JGbY4ybO1hczEjDtoMNWHA=='
-            ),
-            '__VIEWSTATEGENERATOR': 'B345DEBA',
-            '__EVENTVALIDATION': (
-                '/wEdAA1HJ2+J0WZq5G92xJM7n1xbkdMq+p9EbLSDyFDpFsJg30jWLhbIoNprA'
-                'gvONYSktR9kUdPnKtUYGLSZMc/L6M60Vx7WZDZAC7VL6Ff5PQQ8Ml0aq/zmKf'
-                'YeYoLRE68kUnN+T4cvEJcdEKVEObT+JUFSdPwdZycbAgmz2rhziqC/I4jipT0'
-                'jOBb54glnPZxI9VIJZJh1VhVVa0UQ15FhckhgajRdmhEnQj18gON7y5L4CwGM'
-                'p96e++H/oSCxgpNo73nsffQOO+5kepETTltW2pZIXYv2PXYLNUXZnEOvnHkp6'
-                'xZ0N94='
-            ),
-            'ctl00$ContentPlaceHolder1$ddlAgentes': broker.value,
-            'ctl00$ContentPlaceHolder1$ddlContas': default_account,
-            'ctl00$ContentPlaceHolder1$txtDataDeBolsa': start_date,
-            'ctl00$ContentPlaceHolder1$txtDataAteBolsa': end_date,
-            '__ASYNCPOST': True
-        }
-        headers = {
-            'content-type': 'application/x-www-form-urlencoded; charset=UTF-8',
-            'Referer': (
-                'https://cei.b3.com.br/CEI_Responsivo/negociacao-de-ativos.asp'
-                'x'
-            ),
-            'Origin': 'https://cei.b3.com.br',
-            'User-Agent': (
-                'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_6) '
-                'AppleWebKit/537.36 (KHTML, like Gecko) Chrome/84.0.4147.135 '
-                'Safari/537.36')}
-
-        logger.info(
-            f'B3HttpClient getting brokers account - username: {self.username}'
-            f' broker_value: {broker.value}'
+        return await self.session.post(
+            self.base_url, data=payload, headers=self._get_headers()
         )
-
-        response = await self.session.post(
-            self.BROKERS_ACCOUNT_URL,
-            data=payload,
-            headers=headers
-        )
-
-        logger.info(
-            f'B3HttpClient end getting brokers account - '
-            f'username: {self.username} broker_value: {broker.value}'
-        )
-
-        return response
 
     async def get_broker_account_portfolio_assets_extract(
         self,
-        account_id,
-        broker_value,
-        broker_parse_extra_data,
-        account_parse_extra_data
+        broker: Broker,
+        account: BrokerAccount,
+        start_date: Union[date, None] = None,
+        end_date: Union[date, None] = None,
     ):
         if not self.IS_LOGGED:
             await self.login()
 
-        start_date = broker_parse_extra_data.start_date
-        end_date = broker_parse_extra_data.end_date
+        start_date_str = (
+            start_date.strftime("%d/%m/%Y")
+            if start_date is not None
+            else broker.parse_extra_data.start_date
+        )
+        end_date_str = (
+            end_date.strftime("%d/%m/%Y")
+            if end_date is not None
+            else broker.parse_extra_data.end_date
+        )
 
         payload = {
-            'ctl00$ContentPlaceHolder1$ToolkitScriptManager1': (
-                'ctl00$ContentPlaceHolder1$updFiltro|ctl00$ContentPlaceHolder1'
-                '$btnConsultar'
+            "ctl00$ContentPlaceHolder1$ToolkitScriptManager1": (
+                "ctl00$ContentPlaceHolder1$updFiltro|ctl00$ContentPlaceHolder1"
+                "$btnConsultar"
             ),
-            '__EVENTTARGET': '',
-            '__VIEWSTATE': account_parse_extra_data.view_state,
-            '__VIEWSTATEGENERATOR': (
-                account_parse_extra_data.view_state_generator
-            ),
-            '__EVENTVALIDATION': account_parse_extra_data.event_validation,
-            'ctl00$ContentPlaceHolder1$ddlAgentes': broker_value,
-            'ctl00$ContentPlaceHolder1$ddlContas': account_id,
-            'ctl00$ContentPlaceHolder1$txtDataDeBolsa': start_date,
-            'ctl00$ContentPlaceHolder1$txtDataAteBolsa': end_date,
-            'ctl00$ContentPlaceHolder1$btnConsultar': 'Consultar',
-            '__ASYNCPOST': True}
-
-        headers = {
-            'content-type': 'application/x-www-form-urlencoded; charset=UTF-8',
-            'Referer': (
-                'https://cei.b3.com.br/CEI_Responsivo/negociacao-de-ativos.as'
-                'px'
-            ),
-            'Origin': 'https://cei.b3.com.br',
-            'User-Agent': (
-                'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_6) '
-                'AppleWebKit/537.36 (KHTML, like Gecko) Chrome/84.0.4147.135 '
-                'Safari/537.36')}
+            "__EVENTTARGET": "",
+            "__VIEWSTATE": account.parse_extra_data.view_state,
+            "__VIEWSTATEGENERATOR": account.parse_extra_data.view_state_generator,
+            "__EVENTVALIDATION": account.parse_extra_data.event_validation,
+            "ctl00$ContentPlaceHolder1$ddlAgentes": broker.value,
+            "ctl00$ContentPlaceHolder1$ddlContas": account.id,
+            "ctl00$ContentPlaceHolder1$txtDataDeBolsa": start_date_str,
+            "ctl00$ContentPlaceHolder1$txtDataAteBolsa": end_date_str,
+            "ctl00$ContentPlaceHolder1$btnConsultar": "Consultar",
+            "__ASYNCPOST": True,
+        }
 
         logger.info(
-            f'B3HttpClient getting broker account extract portfolio - '
-            f'username: {self.username} '
-            f'broker_value: {broker_value} '
-            f'account_id: {account_id}'
+            f"B3HttpClient getting broker account extract portfolio - "
+            f"username: {self.username} "
+            f"broker_value: {broker.value} "
+            f"account_id: {account.id}"
         )
 
         response = await self.session.post(
-            self.ASSETS_URL,
-            data=payload,
-            headers=headers
+            self.base_url, data=payload, headers=self._get_headers()
         )
         logger.info(
-            f'B3HttpClient end getting broker account extract portfolio - '
-            f'username: {self.username} '
-            f'broker_value: {broker_value}'
+            f"B3HttpClient end getting broker account extract portfolio - "
+            f"username: {self.username} "
+            f"broker_value: {broker.value}"
         )
         return response
+
+    @staticmethod
+    async def _get_date_str(broker: Broker, date: Union[date, None]) -> str:
+        if (
+            date
+            and datetime.strptime(broker.parse_extra_data.start_date, "%d/%m/%Y").date()
+            <= date
+            <= datetime.strptime(broker.parse_extra_data.end_date, "%d/%m/%Y").date()
+        ):
+            # By some reason, CEI will return some "nonsense" data if
+            # we pass a date out of range
+            return date.strftime("%d/%m/%Y")
+        return broker.parse_extra_data.end_date
+
+    async def get_passive_incomes_extract(
+        self, broker: Broker, date: Union[date, None] = None
+    ) -> ClientResponse:
+        if not self.IS_LOGGED:
+            await self.login()
+
+        account = broker.accounts[0]  # accounts[0] it's relative to all accounts
+        payload = {
+            "ctl00$ContentPlaceHolder1$ToolkitScriptManager1": (
+                "ctl00$ContentPlaceHolder1$updFiltro|ctl00$ContentPlaceHolder1"
+                "$btnConsultar"
+            ),
+            "__EVENTTARGET": "",
+            "__VIEWSTATE": account.parse_extra_data.view_state,
+            "__VIEWSTATEGENERATOR": account.parse_extra_data.view_state_generator,
+            "__EVENTVALIDATION": account.parse_extra_data.event_validation,
+            "ctl00$ContentPlaceHolder1$ddlAgentes": broker.value,
+            "ctl00$ContentPlaceHolder1$ddlContas": account.id,
+            "ctl00$ContentPlaceHolder1$txtData": await self._get_date_str(
+                broker=broker, date=date
+            ),
+            "ctl00$ContentPlaceHolder1$btnConsultar": "Consultar",
+            "__ASYNCPOST": True,
+        }
+
+        return await self.session.post(
+            self.base_url, data=payload, headers=self._get_headers()
+        )

--- a/bolsa/models.py
+++ b/bolsa/models.py
@@ -14,7 +14,7 @@ from bolsa.constants import (
     BrokerAssetExtractAction,
     BrokerAssetExtractMarketType,
     PassiveIncomeEventType,
-    PassiveIncomeType,
+    PassiveIncomeType
 )
 
 

--- a/bolsa/models.py
+++ b/bolsa/models.py
@@ -1,3 +1,6 @@
+from __future__ import annotations
+
+import re
 from dataclasses import dataclass, field
 from datetime import datetime
 from decimal import Decimal
@@ -6,19 +9,23 @@ from typing import List
 from bolsa.constants import (
     ASSET_ACTION_TYPE_MAPPER,
     ASSET_MARKET_TYPE_MAPPER,
+    PASSIVE_INCOME_EVENT_TYPE_MAPPER,
+    PASSIVE_INCOME_TYPE_MAPPER,
     BrokerAssetExtractAction,
-    BrokerAssetExtractMarketType
+    BrokerAssetExtractMarketType,
+    PassiveIncomeEventType,
+    PassiveIncomeType,
 )
 
 
 @dataclass
-class BrokerParseExtraData():
+class BrokerParseExtraData:
     start_date: str
     end_date: str
 
 
 @dataclass
-class Broker():
+class Broker:
     value: str
     name: str
     parse_extra_data: BrokerParseExtraData
@@ -26,8 +33,8 @@ class Broker():
 
 
 @dataclass
-class BrokerAccountParseExtraData():
-    """ Essential data to do other requests using account information. """
+class BrokerAccountParseExtraData:
+    """Essential data to do other requests using account information."""
 
     view_state: str
     view_state_generator: str
@@ -35,13 +42,23 @@ class BrokerAccountParseExtraData():
 
 
 @dataclass
-class BrokerAccount():
+class BrokerAccount:
     id: str
     parse_extra_data: BrokerAccountParseExtraData
 
 
+async def _format_string_to_decimal(value: str) -> Decimal:
+    value = value.replace(",", "").replace(".", "")
+    value = f"{value[:-2]}.{value[-2:]}"
+    return Decimal(value)
+
+
+async def _remove_extra_space(text: str) -> str:
+    return re.sub(" +", " ", text)
+
+
 @dataclass
-class BrokerAssetExtract():
+class BrokerAssetExtract:
     operation_date: datetime
     action: BrokerAssetExtractAction
     market_type: BrokerAssetExtractMarketType
@@ -53,7 +70,7 @@ class BrokerAssetExtract():
     quotation_factor: int
 
     @classmethod
-    def create_from_response_fields(
+    async def create_from_response_fields(
         cls,
         operation_date,
         action,
@@ -63,14 +80,15 @@ class BrokerAssetExtract():
         unit_amount,
         unit_price,
         total_price,
-        quotation_factor
-    ):
+        quotation_factor,
+    ) -> BrokerAssetExtract:
         action = ASSET_ACTION_TYPE_MAPPER[action]
         market_type = ASSET_MARKET_TYPE_MAPPER[market_type]
-        operation_date = datetime.strptime(operation_date, '%d/%m/%Y').date()
-        total_price = cls._format_string_to_decimal(total_price)
-        unit_price = cls._format_string_to_decimal(unit_price)
-        unit_amount = int(unit_amount)
+        asset_specification = await _remove_extra_space(asset_specification)
+        operation_date = datetime.strptime(operation_date, "%d/%m/%Y").date()
+        total_price = await _format_string_to_decimal(total_price)
+        unit_price = await _format_string_to_decimal(unit_price)
+        unit_amount = await cls._format_string_to_int(unit_amount)
         quotation_factor = int(quotation_factor)
 
         return cls(
@@ -82,11 +100,63 @@ class BrokerAssetExtract():
             unit_amount=unit_amount,
             unit_price=unit_price,
             total_price=total_price,
-            quotation_factor=quotation_factor
+            quotation_factor=quotation_factor,
         )
 
     @staticmethod
-    def _format_string_to_decimal(value):
-        value = value.replace(',', '').replace('.', '')
-        value = f'{value[:-2]}.{value[-2:]}'
-        return Decimal(value)
+    async def _format_string_to_int(value: str) -> int:
+        return int(value.replace(".", ""))
+
+
+@dataclass
+class PassiveIncome:
+    raw_negotiation_name: str
+    asset_specification: str
+    raw_negotiation_code: str
+    operation_date: datetime
+    event_type: PassiveIncomeEventType
+    unit_amount: int
+    quotation_factor: int
+    gross_value: Decimal
+    net_value: Decimal
+    income_type: PassiveIncomeType
+
+    @classmethod
+    async def create_from_response_fields(
+        cls,
+        raw_negotiation_name,
+        asset_specification,
+        raw_negotiation_code,
+        operation_date,
+        event_type,
+        unit_amount,
+        quotation_factor,
+        gross_value,
+        net_value,
+        income_type,
+    ) -> PassiveIncome:
+        asset_specification = await _remove_extra_space(asset_specification)
+        operation_date = datetime.strptime(operation_date, "%d/%m/%Y").date()
+        event_type = PASSIVE_INCOME_EVENT_TYPE_MAPPER.get(event_type)
+        unit_amount = await cls._format_string_to_int(unit_amount)
+        quotation_factor = int(quotation_factor)
+        gross_value = await _format_string_to_decimal(gross_value)
+        net_value = await _format_string_to_decimal(net_value)
+        income_type = PASSIVE_INCOME_TYPE_MAPPER.get(income_type)
+
+        return cls(
+            raw_negotiation_name=raw_negotiation_name,
+            asset_specification=asset_specification,
+            raw_negotiation_code=raw_negotiation_code,
+            operation_date=operation_date,
+            event_type=event_type,
+            unit_amount=unit_amount,
+            quotation_factor=quotation_factor,
+            gross_value=gross_value,
+            net_value=net_value,
+            income_type=income_type,
+        )
+
+    @staticmethod
+    async def _format_string_to_int(value: str) -> int:
+        return int(value.split(",")[0].replace(".", ""))

--- a/bolsa/responses.py
+++ b/bolsa/responses.py
@@ -1,78 +1,98 @@
 import logging
+import re
+from typing import Any, Dict, Iterator, List, Tuple, Union
 
+from aiohttp.client_reqrep import ClientResponse
 from bs4 import BeautifulSoup
+from bs4.element import ResultSet, Tag
 
 from bolsa.models import (
     Broker,
     BrokerAccount,
     BrokerAccountParseExtraData,
     BrokerAssetExtract,
-    BrokerParseExtraData
+    BrokerParseExtraData,
+    PassiveIncome,
 )
 
 logger = logging.getLogger(__name__)
 
 
-class GetBrokersResponse():
-    BROKERS_SELECT_ID = 'ctl00_ContentPlaceHolder1_ddlAgentes'
-    DEFAULT_INVALID_BROKER_VALUE = '-1'
+class _BrokerResponseBase:
+    BROKERS_SELECT_ID = "ctl00_ContentPlaceHolder1_ddlAgentes"
+    DEFAULT_INVALID_BROKER_VALUE = "-1"
 
-    def __init__(self, response):
+    def __init__(self, response: ClientResponse) -> None:
         self.response = response
 
-    async def data(self):
+    @staticmethod
+    def _get_date_input_ids() -> Tuple[str, str]:
+        raise NotImplementedError()
+
+    async def data(self) -> List[Broker]:
         html = await self.response.text()
-        return self._parse_get_brokers(html)
+        return self._parse_brokers(html)
 
-    def _parse_get_brokers(self, html):
-        soup = BeautifulSoup(html, 'html.parser')
-        brokers_select = soup.find('select', id=self.BROKERS_SELECT_ID)
-        brokers_option = brokers_select.find_all('option')
-
-        start_date = soup.find(
-            id='ctl00_ContentPlaceHolder1_txtDataDeBolsa'
-        )['value']
-        end_date = soup.find(
-            id='ctl00_ContentPlaceHolder1_txtDataAteBolsa'
-        )['value']
+    def _parse_brokers(self, html: str) -> List[Broker]:
+        soup = BeautifulSoup(html, "html.parser")
+        brokers_select = soup.find("select", id=self.BROKERS_SELECT_ID)
+        brokers_option = brokers_select.find_all("option")
+        start_date_id, end_date_id = self._get_date_input_ids()
+        start_date = soup.find(id=start_date_id).text
+        end_date = soup.find(id=end_date_id).text
 
         return [
             Broker(
                 name=broker_option.text,
-                value=broker_option['value'],
-                parse_extra_data=BrokerParseExtraData(start_date, end_date)
+                value=broker_option["value"],
+                parse_extra_data=BrokerParseExtraData(start_date, end_date),
             )
             for broker_option in brokers_option
-            if broker_option['value'] != self.DEFAULT_INVALID_BROKER_VALUE
+            if broker_option["value"] != self.DEFAULT_INVALID_BROKER_VALUE
         ]
 
 
-class GetBrokerAccountResponse():
-    ACCOUNT_SELECT_ID = 'ctl00_ContentPlaceHolder1_ddlContas'
-    BROKERS_SELECT_ID = 'ctl00_ContentPlaceHolder1_ddlAgentes'
+class BrokerAssetsResponse(_BrokerResponseBase):
+    @staticmethod
+    def _get_date_input_ids() -> Tuple[str, str]:
+        start_date_id = "ctl00_ContentPlaceHolder1_lblPeriodoInicialBolsa"
+        end_date_id = "ctl00_ContentPlaceHolder1_lblPeriodoFinalBolsa"
+        return start_date_id, end_date_id
 
-    def __init__(self, response, broker):
+
+class BrokerPassiveIncomesResponse(_BrokerResponseBase):
+    @staticmethod
+    def _get_date_input_ids() -> Tuple[str, str]:
+        start_date_id = "ctl00_ContentPlaceHolder1_lblPeriodoInicial"
+        end_date_id = "ctl00_ContentPlaceHolder1_lblPeriodoFinal"
+        return start_date_id, end_date_id
+
+
+class BrokerAccountResponse:
+    ACCOUNT_SELECT_ID = "ctl00_ContentPlaceHolder1_ddlContas"
+    BROKERS_SELECT_ID = "ctl00_ContentPlaceHolder1_ddlAgentes"
+
+    def __init__(self, response: ClientResponse, broker: Broker) -> None:
         self.response = response
         self.broker = broker
 
-    async def data(self):
+    async def data(self) -> Broker:
         html = await self.response.text()
 
-        self.broker.accounts = self._parse_get_accounts(html)
+        self.broker.accounts = await self._parse_accounts(html)
 
         return self.broker
 
-    def _parse_get_accounts(self, html):
-        soup = BeautifulSoup(html, 'html.parser')
-        brokers_select = soup.find('select', id=self.ACCOUNT_SELECT_ID)
+    async def _parse_accounts(self, html: str) -> List[BrokerAccount]:
+        soup = BeautifulSoup(html, "html.parser")
+        brokers_select = soup.find("select", id=self.ACCOUNT_SELECT_ID)
         if not brokers_select:
             return []
 
-        brokers_option = brokers_select.find_all('option')
-
-        view_state = soup.find(id='__VIEWSTATE')['value']
-        view_state_generator = soup.find(id='__VIEWSTATEGENERATOR')['value']
-        event_validation = soup.find(id='__EVENTVALIDATION')['value']
+        brokers_option = brokers_select.find_all("option")
+        view_state = soup.find(id="__VIEWSTATE")["value"]
+        view_state_generator = soup.find(id="__VIEWSTATEGENERATOR")["value"]
+        event_validation = soup.find(id="__EVENTVALIDATION")["value"]
 
         parse_extra_data = BrokerAccountParseExtraData(
             view_state=view_state,
@@ -81,50 +101,55 @@ class GetBrokerAccountResponse():
         )
 
         return [
-            BrokerAccount(
-                id=broker_option['value'],
-                parse_extra_data=parse_extra_data
-            )
+            BrokerAccount(id=broker_option["value"], parse_extra_data=parse_extra_data)
             for broker_option in brokers_option
         ]
 
 
-class GetBrokerAccountAssetExtractResponse:
+class BrokerAccountAssetExtractResponse:
     ASSETS_TABLE_ID = (
-        'ctl00_ContentPlaceHolder1_rptAgenteBolsa_ctl00_rptContaBolsa_ctl00_'
-        'pnAtivosNegociados'
+        "ctl00_ContentPlaceHolder1_rptAgenteBolsa_ctl00_rptContaBolsa_ctl00_"
+        "pnAtivosNegociados"
     )
 
-    def __init__(self, response, broker_value):
+    def __init__(self, response: ClientResponse, broker_value: str) -> None:
         self.response = response
         self.broker_value = broker_value
 
-    async def data(self):
+    async def data(
+        self, as_dict: bool = False
+    ) -> Union[List[BrokerAssetExtract], List[Dict[str, Any]]]:
         html = await self.response.text()
+        return await self._parse_assets_extract(html, as_dict=as_dict)
 
-        assets_extract = await self._parse_get_assets_extract(html)
-        return assets_extract
-
-    async def _parse_get_assets_extract(self, html):
+    async def _parse_assets_extract(
+        self, html: str, as_dict: bool
+    ) -> Union[List[BrokerAssetExtract], List[Dict[str, Any]]]:
         assets_extract = []
-        soup = BeautifulSoup(html, 'html.parser')
+        soup = BeautifulSoup(html, "html.parser")
         assets_table = soup.find(id=self.ASSETS_TABLE_ID)
 
         logger.debug(
-            f'GetBrokerAccountAssetExtractResponse start parsing asset extract'
-            f' - broker value: {self.broker_value}'
+            f"BrokerAccountAssetExtractResponse start parsing asset extract"
+            f" - broker value: {self.broker_value}"
         )
 
-        if not assets_table:
-            return assets_extract
-
-        table_body = assets_table.find('tbody')
-        rows = table_body.find_all('tr')
+        table_body = assets_table.find("tbody") if assets_table else ResultSet(None)
+        rows = table_body.find_all("tr") if table_body else []
         for row in rows:
-            operation_date, action, market_type, _, raw_negotiation_code, asset_specification, unit_amount, unit_price, total_price, quotation_factor = row.find_all(  # NOQA
-                'td'
-            )
-            asset_extract = BrokerAssetExtract.create_from_response_fields(
+            (
+                operation_date,
+                action,
+                market_type,
+                _,
+                raw_negotiation_code,
+                asset_specification,
+                unit_amount,
+                unit_price,
+                total_price,
+                quotation_factor,
+            ) = row.find_all("td")
+            asset_extract = await BrokerAssetExtract.create_from_response_fields(
                 operation_date=operation_date.get_text(strip=True),
                 action=action.get_text(strip=True),
                 market_type=market_type.get_text(strip=True),
@@ -133,13 +158,97 @@ class GetBrokerAccountAssetExtractResponse:
                 unit_amount=unit_amount.get_text(strip=True),
                 unit_price=unit_price.get_text(strip=True),
                 total_price=total_price.get_text(strip=True),
-                quotation_factor=quotation_factor.get_text(strip=True)
+                quotation_factor=quotation_factor.get_text(strip=True),
             )
-            assets_extract.append(asset_extract)
+            assets_extract.append(asset_extract.__dict__ if as_dict else asset_extract)
 
         logger.debug(
-            f'GetBrokerAccountAssetExtractResponse end parsing asset extract '
-            f'- broker value: {self.broker_value}'
+            f"BrokerAccountAssetExtractResponse end parsing asset extract "
+            f"- broker value: {self.broker_value}"
         )
 
         return assets_extract
+
+
+class PassiveIncomesResponse:
+    PASSIVE_INCOMES_DOCUMENT_ID = "ctl00_ContentPlaceHolder1_updFiltro"
+    BROKER_TITLE_ID_REGEX = (
+        r"ctl00_ContentPlaceHolder1_rptAgenteProventos.*lblAgenteProventos"
+    )
+    UNSUPPORTED_INCOME_TYPE = "Eventos em Ativos Creditado"
+
+    def __init__(self, response: ClientResponse) -> None:
+        self.response = response
+
+    async def data(
+        self, as_dict: bool = False
+    ) -> Union[List[PassiveIncome], List[Dict[str, Any]]]:
+        html = await self.response.text()
+        return await self._parse_data(html=html, as_dict=as_dict)
+
+    @staticmethod
+    async def _parse_passive_incomes(
+        table: Tag, income_type: str
+    ) -> Iterator[PassiveIncome]:
+        for row in table.find_all("tr"):
+            (
+                raw_negotiation_name,
+                asset_specification,
+                raw_negotiation_code,
+                operation_date,
+                event_type,
+                unit_amount,
+                quotation_factor,
+                gross_value,
+                net_value,
+            ) = row.find_all("td")
+            yield await PassiveIncome.create_from_response_fields(
+                raw_negotiation_name=raw_negotiation_name.get_text(strip=True),
+                asset_specification=asset_specification.get_text(strip=True),
+                raw_negotiation_code=raw_negotiation_code.get_text(strip=True),
+                operation_date=operation_date.get_text(strip=True),
+                event_type=event_type.get_text(strip=True),
+                unit_amount=unit_amount.get_text(strip=True),
+                quotation_factor=quotation_factor.get_text(strip=True),
+                gross_value=gross_value.get_text(strip=True),
+                net_value=net_value.get_text(strip=True),
+                income_type=income_type,
+            )
+
+    @staticmethod
+    async def _get_income_types(broker_tag: Tag, method_name: str) -> ResultSet:
+        method = getattr(broker_tag, method_name)
+        return method("p", class_="title")
+
+    async def _parse_data(
+        self, html: str, as_dict: bool
+    ) -> Union[List[PassiveIncome], List[Dict[str, Any]]]:
+        passive_incomes = []
+        soup = BeautifulSoup(html, "html.parser")
+        document = soup.find(id=self.PASSIVE_INCOMES_DOCUMENT_ID)
+        brokers = document.find_all(id=re.compile(self.BROKER_TITLE_ID_REGEX))
+        num_of_brokers = len(brokers)
+
+        for i in range(num_of_brokers):
+            if i + 1 == num_of_brokers:  # last broker
+                broker_tag = brokers[i]
+                method_name = "find_all_next"
+            else:
+                broker_tag = brokers[i + 1]
+                method_name = "find_all_previous"
+
+            for income_type in await self._get_income_types(
+                broker_tag=broker_tag, method_name=method_name
+            ):
+                if income_type.get_text(strip=True) == self.UNSUPPORTED_INCOME_TYPE:
+                    continue
+
+                async for passive_income in self._parse_passive_incomes(
+                    table=income_type.find_next("tbody") or [],
+                    income_type=income_type.get_text(strip=True).split()[-1],
+                ):
+                    passive_incomes.append(
+                        passive_income.__dict__ if as_dict else passive_income
+                    )
+
+        return passive_incomes

--- a/bolsa/responses.py
+++ b/bolsa/responses.py
@@ -12,7 +12,7 @@ from bolsa.models import (
     BrokerAccountParseExtraData,
     BrokerAssetExtract,
     BrokerParseExtraData,
-    PassiveIncome
+    PassiveIncome,
 )
 
 logger = logging.getLogger(__name__)
@@ -26,18 +26,18 @@ class _BrokerResponseBase:
         self.response = response
 
     @staticmethod
-    def _get_date_input_ids() -> Tuple[str, str]:
+    async def _get_date_input_ids() -> Tuple[str, str]:
         raise NotImplementedError()
 
     async def data(self) -> List[Broker]:
         html = await self.response.text()
-        return self._parse_brokers(html)
+        return await self._parse_brokers(html)
 
-    def _parse_brokers(self, html: str) -> List[Broker]:
+    async def _parse_brokers(self, html: str) -> List[Broker]:
         soup = BeautifulSoup(html, "html.parser")
         brokers_select = soup.find("select", id=self.BROKERS_SELECT_ID)
         brokers_option = brokers_select.find_all("option")
-        start_date_id, end_date_id = self._get_date_input_ids()
+        start_date_id, end_date_id = await self._get_date_input_ids()
         start_date = soup.find(id=start_date_id).text
         end_date = soup.find(id=end_date_id).text
 
@@ -54,7 +54,7 @@ class _BrokerResponseBase:
 
 class BrokerAssetsResponse(_BrokerResponseBase):
     @staticmethod
-    def _get_date_input_ids() -> Tuple[str, str]:
+    async def _get_date_input_ids() -> Tuple[str, str]:
         start_date_id = "ctl00_ContentPlaceHolder1_lblPeriodoInicialBolsa"
         end_date_id = "ctl00_ContentPlaceHolder1_lblPeriodoFinalBolsa"
         return start_date_id, end_date_id
@@ -62,7 +62,7 @@ class BrokerAssetsResponse(_BrokerResponseBase):
 
 class BrokerPassiveIncomesResponse(_BrokerResponseBase):
     @staticmethod
-    def _get_date_input_ids() -> Tuple[str, str]:
+    async def _get_date_input_ids() -> Tuple[str, str]:
         start_date_id = "ctl00_ContentPlaceHolder1_lblPeriodoInicial"
         end_date_id = "ctl00_ContentPlaceHolder1_lblPeriodoFinal"
         return start_date_id, end_date_id

--- a/bolsa/responses.py
+++ b/bolsa/responses.py
@@ -1,6 +1,6 @@
 import logging
 import re
-from typing import Any, Dict, Iterator, List, Tuple, Union
+from typing import Any, AsyncGenerator, Dict, List, Tuple, Union
 
 from aiohttp.client_reqrep import ClientResponse
 from bs4 import BeautifulSoup
@@ -12,7 +12,7 @@ from bolsa.models import (
     BrokerAccountParseExtraData,
     BrokerAssetExtract,
     BrokerParseExtraData,
-    PassiveIncome,
+    PassiveIncome
 )
 
 logger = logging.getLogger(__name__)
@@ -167,7 +167,7 @@ class BrokerAccountAssetExtractResponse:
             f"- broker value: {self.broker_value}"
         )
 
-        return assets_extract
+        return assets_extract  # type: ignore
 
 
 class PassiveIncomesResponse:
@@ -189,7 +189,7 @@ class PassiveIncomesResponse:
     @staticmethod
     async def _parse_passive_incomes(
         table: Tag, income_type: str
-    ) -> Iterator[PassiveIncome]:
+    ) -> AsyncGenerator[PassiveIncome, None]:
         for row in table.find_all("tr"):
             (
                 raw_negotiation_name,
@@ -251,4 +251,4 @@ class PassiveIncomesResponse:
                         passive_income.__dict__ if as_dict else passive_income
                     )
 
-        return passive_incomes
+        return passive_incomes  # type: ignore

--- a/bolsa/test/test_constants.py
+++ b/bolsa/test/test_constants.py
@@ -9,21 +9,24 @@ from bolsa.constants import (
 
 
 class TestConstantsMapper:
-
+    @pytest.mark.asyncio
     @pytest.mark.parametrize(
-        'key, expected_value',
+        "key, expected_value",
         [
-            ('C', BrokerAssetExtractAction.BUY.value),
-            ('V', BrokerAssetExtractAction.SELL.value)
-        ]
+            ("C", BrokerAssetExtractAction.BUY.value),
+            ("V", BrokerAssetExtractAction.SELL.value),
+        ],
     )
     async def test_asset_action_type_mapper(self, key, expected_value):
         assert ASSET_ACTION_TYPE_MAPPER[key] == expected_value
 
-    @pytest.mark.parametrize('key, expected_value',
-                             [('Merc. Fracionário',
-                               BrokerAssetExtractMarketType.FRACTIONAL.value),
-                              ('Mercado a Vista',
-                                 BrokerAssetExtractMarketType.UNIT.value)])
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "key, expected_value",
+        [
+            ("Merc. Fracionário", BrokerAssetExtractMarketType.FRACTIONAL.value),
+            ("Mercado a Vista", BrokerAssetExtractMarketType.UNIT.value),
+        ],
+    )
     async def test_asset_market_type_mapper(self, key, expected_value):
         assert ASSET_MARKET_TYPE_MAPPER[key] == expected_value

--- a/bolsa/test/test_models.py
+++ b/bolsa/test/test_models.py
@@ -1,36 +1,44 @@
-from datetime import date
+from datetime import date, datetime
 from decimal import Decimal
+
+import pytest
 
 from bolsa.constants import (
     BrokerAssetExtractAction,
-    BrokerAssetExtractMarketType
+    BrokerAssetExtractMarketType,
+    PassiveIncomeEventType,
+    PassiveIncomeType
 )
-from bolsa.models import BrokerAssetExtract
+from bolsa.models import (
+    BrokerAssetExtract,
+    PassiveIncome,
+    _format_string_to_decimal
+)
 
 
 class TestBrokerAssetExtract:
-
-    async def test_create_object_from_response_data(self):
-        action = 'C'
-        asset_specification = 'AZUL        PN      N2'
-        market_type = 'Merc. Fracionário'
-        operation_date = '05/06/2020'
-        quotation_factor = '1'
-        raw_negotiation_code = 'AZUL4F'
-        total_price = '42,18'
-        unit_amount = '2'
-        unit_price = '21,09'
+    @pytest.mark.asyncio
+    async def test_create_asset_from_response_data(self):
+        action = "C"
+        asset_specification = "AZUL        PN      N2"
+        market_type = "Merc. Fracionário"
+        operation_date = "05/06/2020"
+        quotation_factor = "1"
+        raw_negotiation_code = "AZUL4F"
+        total_price = "42,18"
+        unit_amount = "2"
+        unit_price = "21,09"
 
         expected_obj = BrokerAssetExtract(
             action=BrokerAssetExtractAction.BUY.value,
-            asset_specification=asset_specification,
+            asset_specification="AZUL PN N2",
             market_type=BrokerAssetExtractMarketType.FRACTIONAL.value,
             operation_date=date(2020, 6, 5),
             quotation_factor=1,
             raw_negotiation_code=raw_negotiation_code,
-            total_price=Decimal('42.18'),
+            total_price=Decimal("42.18"),
             unit_amount=2,
-            unit_price=Decimal('21.09')
+            unit_price=Decimal("21.09"),
         )
 
         broker_asset_extract = BrokerAssetExtract.create_from_response_fields(
@@ -42,15 +50,95 @@ class TestBrokerAssetExtract:
             raw_negotiation_code=raw_negotiation_code,
             total_price=total_price,
             unit_amount=unit_amount,
-            unit_price=unit_price
+            unit_price=unit_price,
         )
 
         assert broker_asset_extract == expected_obj
 
+    @pytest.mark.asyncio
     async def test_format_string_to_decimal_with_high_value(self):
-        expected_value = Decimal('1485.12')
-        unit_price = '1.485.12'
+        expected_value = Decimal("1485.12")
+        unit_price = "1.485.12"
 
-        value = BrokerAssetExtract._format_string_to_decimal(unit_price)
+        value = _format_string_to_decimal(unit_price)
 
         assert value == expected_value
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "expected_value, unit_amount",
+        [(1, "1"), (1100, "1.100"), (1000000, "1.000.000")],
+    )
+    async def test_should_format_asset_string_to_int(self, expected_value, unit_amount):
+        # GIVEN
+
+        # WHEN
+        value = BrokerAssetExtract._format_string_to_int(unit_amount)
+
+        # THEN
+        assert value == expected_value
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "expected_value, unit_amount",
+        [
+            (1, "1,00"),
+            (100, "100,00"),
+            (1100, "1.100,00"),
+            (1000000, "1.000.000,00"),
+        ],
+    )
+    async def test_should_format_passive_income_string_to_int(
+        self, expected_value, unit_amount
+    ):
+        # GIVEN
+
+        # WHEN
+        value = PassiveIncome._format_string_to_int(unit_amount)
+
+        # THEN
+        assert value == expected_value
+
+    @pytest.mark.asyncio
+    async def test_create_passive_income_from_response_data(self):
+        # GIVEN
+        raw_negotiation_name = "ALUPAR"
+        asset_specification = "UNT      N2"
+        raw_negotiation_code = "ALUP11"
+        operation_date = "05/06/2020"
+        event_type = "DIVIDENDO"
+        unit_amount = "2"
+        quotation_factor = "1"
+        gross_value = "35,70"
+        net_value = "35,70"
+        income_type = "Provisionado"
+
+        expected_obj = PassiveIncome(
+            raw_negotiation_name=raw_negotiation_name,
+            asset_specification="UNT N2",
+            raw_negotiation_code=raw_negotiation_code,
+            operation_date=date(2020, 6, 5),
+            event_type=PassiveIncomeEventType.DIVIDEND.value,
+            unit_amount=2,
+            quotation_factor=1,
+            gross_value=Decimal("35.70"),
+            net_value=Decimal("35.70"),
+            income_type=PassiveIncomeType.FUTURE.value,
+        )
+
+        # WHEN
+        passive_income = PassiveIncome.create_from_response_fields(
+            raw_negotiation_name=raw_negotiation_name,
+            asset_specification=asset_specification,
+            raw_negotiation_code=raw_negotiation_code,
+            operation_date=operation_date,
+            event_type=event_type,
+            unit_amount=unit_amount,
+            quotation_factor=quotation_factor,
+            gross_value=gross_value,
+            net_value=net_value,
+            income_type=income_type,
+        )
+
+        # THEN
+        assert passive_income == expected_obj

--- a/bolsa/test/test_models.py
+++ b/bolsa/test/test_models.py
@@ -1,4 +1,4 @@
-from datetime import date, datetime
+from datetime import date
 from decimal import Decimal
 
 import pytest
@@ -7,13 +7,9 @@ from bolsa.constants import (
     BrokerAssetExtractAction,
     BrokerAssetExtractMarketType,
     PassiveIncomeEventType,
-    PassiveIncomeType
+    PassiveIncomeType,
 )
-from bolsa.models import (
-    BrokerAssetExtract,
-    PassiveIncome,
-    _format_string_to_decimal
-)
+from bolsa.models import BrokerAssetExtract, PassiveIncome, _format_string_to_decimal
 
 
 class TestBrokerAssetExtract:

--- a/setup.py
+++ b/setup.py
@@ -3,39 +3,39 @@ import sys
 import setuptools
 
 if sys.version_info < (3, 8):
-    raise RuntimeError('bolsa requires Python 3.8+')
+    raise RuntimeError("bolsa requires Python 3.8+")
 
-with open('README.md', 'r') as fh:
+with open("README.md", "r") as fh:
     long_description = fh.read()
 
 install_requires = [
-    'aiohttp>=3.6.2,<4.0.0',
-    'cchardet>=2.1.6',
-    'aiodns>=2.0.0',
-    'beautifulsoup4>=4.9.2',
+    "aiohttp>=3.6.2,<4.0.0",
+    "cchardet>=2.1.6",
+    "aiodns>=2.0.0",
+    "beautifulsoup4>=4.9.2",
 ]
 
 
 setuptools.setup(
-    name='bolsa',
-    version='2.1.0',
+    name="bolsa",
+    version="2.2.0",
     packages=setuptools.find_packages(),
-    python_requires='>=3.8.*',
-    author='Giovanni Cornachini',
-    author_email='giovannicornachini@gmail.com',
+    python_requires=">=3.8.*",
+    author="Giovanni Cornachini",
+    author_email="giovannicornachini@gmail.com",
     description=(
-        'Biblioteca feita em python com o objetivo de facilitar o acesso a '
-        'dados de seus investimentos na bolsa de valores(B3/CEI).'
+        "Biblioteca feita em python com o objetivo de facilitar o acesso a "
+        "dados de seus investimentos na bolsa de valores(B3/CEI)."
     ),
     long_description=long_description,
-    long_description_content_type='text/markdown',
-    url='https://github.com/gicornachini/bolsa',
+    long_description_content_type="text/markdown",
+    url="https://github.com/gicornachini/bolsa",
     install_requires=install_requires,
     classifiers=[
-        'License :: OSI Approved :: Apache Software License',
-        'Programming Language :: Python',
-        'Programming Language :: Python :: 3.8',
-        'Operating System :: MacOS :: MacOS X',
-        'Operating System :: Microsoft :: Windows'
+        "License :: OSI Approved :: Apache Software License",
+        "Programming Language :: Python",
+        "Programming Language :: Python :: 3.8",
+        "Operating System :: MacOS :: MacOS X",
+        "Operating System :: Microsoft :: Windows",
     ],
 )


### PR DESCRIPTION
Boa noite!

Primeiramente: muito obrigado pela biblioteca!

De maneira resumida, esse PR inclui/altera:

- Método `get_passive_incomes_extract`, que obtém os proventos do CEI;
- Inclusão de parâmetros de data (`start_date` e `end_date`) para filtrar `BrokerAssetExtract`;
- Simplificação do argumentos do método `get_broker_account_portfolio_assets_extract`: apenas `broker` e `account` são necessários;
- Adição do parâmetro `as_dict` nos métodos `get_broker_account_portfolio_assets_extract` e `get_brokers_account_portfolio_assets_extract`. Eu pretendo usar o crawler dentro de um microserviço num projeto pessoal e quero expor os resultados por meio de uma API. Em cenários desse tipo penso que é muito mais fácil tratar os dados direto como `dict` do que como objetos `dataclass`. É uma mudança bem simples que pode ajudar mais pessoas;
- Também incluí tratativas para solicitações sem sucesso de login;
- Adicionei tipagem em (quase?) todos os métodos.

Eu usei o black como formatter e o pylint como linter, espero que não tenha problema (imagino que você usou o flake8, mas não vi nenhum arquivo de configuração).

Não ajustei a documentação, pois não sei se você vai aceitar. Mas, caso aceite, me proponho a ajustá-la!